### PR TITLE
Cleanups and speedups for T::P and T::P::Grid construction

### DIFF
--- a/lib/Terminal/Print.pm6
+++ b/lib/Terminal/Print.pm6
@@ -64,7 +64,6 @@ has Terminal::Print::Grid $.current-grid handles 'indices';
 
 has Terminal::Print::Grid @.grids;
 
-has @.indices;
 has %!grid-name-map;
 
 has $.columns;

--- a/lib/Terminal/Print.pm6
+++ b/lib/Terminal/Print.pm6
@@ -60,7 +60,7 @@ we might be able to get from using Perl 6 -- easy async abstractions.
 
 use Terminal::Print::Grid;
 
-has Terminal::Print::Grid $.current-grid;
+has Terminal::Print::Grid $.current-grid handles 'indices';
 
 has Terminal::Print::Grid @.grids;
 
@@ -89,21 +89,18 @@ method new( :$cursor-profile = 'ansi' ) {
     my $move-cursor = move-cursor-template($cursor-profile);
 
     my $grid = Terminal::Print::Grid.new( $columns, $rows, :$move-cursor );
-    my @indices = $grid.indices;
 
     self.bless(
-                :$columns, :$rows, :@indices,
+                :$columns, :$rows,
                 :$cursor-profile, :$move-cursor,
                     current-grid    => $grid,
               );
 }
 
-submethod BUILD( :$current-grid, :$!columns, :$!rows, :@indices, :$!cursor-profile, :$!move-cursor ) {
+submethod BUILD( :$current-grid, :$!columns, :$!rows, :$!cursor-profile, :$!move-cursor ) {
     push @!grids, $current-grid;
 
     $!current-grid := @!grids[0];
-
-    @!indices = @indices;  # TODO: bind this to @!grids[0].indices?
 
     # set up a tap on SIGINT so that we can cleanly shutdown, restoring the previous screen and cursor
     signal(SIGINT).tap: {

--- a/lib/Terminal/Print.pm6
+++ b/lib/Terminal/Print.pm6
@@ -84,23 +84,17 @@ has Terminal::Print::CursorProfile $.cursor-profile;
 has $.move-cursor;
 
 method new( :$cursor-profile = 'ansi' ) {
-    my $columns   = +%Commands::attributes<columns>;
-    my $rows      = +%Commands::attributes<rows>;
-    my $move-cursor = move-cursor-template($cursor-profile);
+    my $columns      = +%Commands::attributes<columns>;
+    my $rows         = +%Commands::attributes<rows>;
+    my $move-cursor  = move-cursor-template($cursor-profile);
+    my $current-grid = Terminal::Print::Grid.new( $columns, $rows, :$move-cursor );
 
-    my $grid = Terminal::Print::Grid.new( $columns, $rows, :$move-cursor );
-
-    self.bless(
-                :$columns, :$rows,
-                :$cursor-profile, :$move-cursor,
-                    current-grid    => $grid,
-              );
+    self.bless( :$columns, :$rows, :$current-grid,
+                :$cursor-profile,  :$move-cursor );
 }
 
-submethod BUILD( :$current-grid, :$!columns, :$!rows, :$!cursor-profile, :$!move-cursor ) {
-    push @!grids, $current-grid;
-
-    $!current-grid := @!grids[0];
+submethod BUILD( :$!current-grid, :$!columns, :$!rows, :$!cursor-profile, :$!move-cursor ) {
+    push @!grids, $!current-grid;
 
     # set up a tap on SIGINT so that we can cleanly shutdown, restoring the previous screen and cursor
     signal(SIGINT).tap: {

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -25,10 +25,8 @@ has $!print-enabled = True;
 
 method new($columns, $rows, :$move-cursor) {
     my @indices = (^$columns X ^$rows)>>.Array;
-    my @grid;
-    for @indices -> [$x, $y] {
-        @grid[$x][$y] = " ";
-    }
+    my @grid = [ [ ' ' xx $rows ] xx $columns ];
+
     $move-cursor //= move-cursor-template;
 
     self.bless(:$columns, :$rows, :@grid, :@indices, :$move-cursor);

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -17,19 +17,22 @@ my class Cell {
 
 has $.rows;
 has $.columns;
-has @.indices;
+has @!indices;
 has @.grid;
 has $.grid-string = '';
 has $.move-cursor;
 has $!print-enabled = True;
 
 method new($columns, $rows, :$move-cursor) {
-    my @indices = (^$columns X ^$rows)>>.Array;
     my @grid = [ [ ' ' xx $rows ] xx $columns ];
 
     $move-cursor //= move-cursor-template;
 
-    self.bless(:$columns, :$rows, :@grid, :@indices, :$move-cursor);
+    self.bless(:$columns, :$rows, :@grid, :$move-cursor);
+}
+
+method indices() {
+    @!indices ||= (^$.columns X ^$.rows)>>.Array;
 }
 
 method cell-string($x, $y) {


### PR DESCRIPTION
5 commits (plus a merge) that clean up and speed up construction of T::P and T::P::Grid.

At this point the major slowdown at initial startup is loading T::P itself, because of the remaining 'no precompilation' infection from OO::Monitors; discussing that separately with jnthn.
