### PR TITLE
Performance and start of span refactoring

### DIFF
--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -54,15 +54,13 @@ INIT {
         }
 
         my $raw = %cached<cup>;
-        # Replace the digits with format specifiers used
-        # by sprintf
-        $raw ~~ s:nth(*-1)[\d+] = "%d";
-        $raw ~~ s:nth(*)[\d+]   = "%d";
-        $raw ||= '';
+        $raw ~~ /^ (.*?) (\d+) (\D+) (\d+) (\D+) $/
+            or warn "universal mode must have access to tput";
+
+        my ($pre, $mid, $post) = $0, $2, $4;
 
         my Str sub universal( Int() $x, Int() $y ) {
-            warn "universal mode must have access to tput" unless $raw;
-            sprintf($raw, $y + 1, $x + 1)
+            $pre ~ ($y + 1) ~ $mid ~ ($x + 1) ~ $post;
         }
 
         return %( :&ansi, :&universal );

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -93,10 +93,7 @@ method disable {
 }
 
 method Str {
-    unless $!grid-string {
-        for @!indices -> [$x, $y] {
-            $!grid-string ~= self.cell-string($x, $y);
-        }
+    $!grid-string ||= join '', ^$!rows .map: -> $y {
+        $!move-cursor(0, $y) ~ (^$!columns .map(-> $x { @!grid[$x][$y] }).join)
     }
-    $!grid-string
 }

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -39,6 +39,10 @@ method cell-string($x, $y) {
     "{$!move-cursor($x, $y)}{~@!grid[$x][$y]}"
 }
 
+method span-string($y, $x1 = 0, $x2 = $!columns - 1) {
+    $!move-cursor($x1, $y) ~ ($x1..$x2).map(-> $x { @!grid[$x][$y] }).join
+}
+
 multi method change-cell($x, $y, %c) {
     $!grid-string = '';
     @!grid[$x][$y] = Cell.new(|%c)
@@ -93,7 +97,5 @@ method disable {
 }
 
 method Str {
-    $!grid-string ||= join '', ^$!rows .map: -> $y {
-        $!move-cursor(0, $y) ~ (^$!columns .map(-> $x { @!grid[$x][$y] }).join)
-    }
+    $!grid-string ||= join '', ^$!rows .map({ self.span-string($_) });
 }


### PR DESCRIPTION
Three commits: Two that add significant speedups for 'universal' mode cursor movement and T::P::Grid.Str, plus one that does a minor refactor to pull out a span-string() method similar to cell-string(), but providing a more efficient result for drawing an entire span.