### PR TITLE
Fixed some bugs in terminal and capa querying.

### DIFF
--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -1,4 +1,5 @@
-unit module Terminal::Print::Commands;
+module Terminal::Print::Commands
+{
 
 =begin pod
 =title Terminal::Print::Commands
@@ -23,7 +24,14 @@ our @styles    = [ <reset bold underline inverse> ];
 subset Terminal::Print::CursorProfile is export where * ~~ / ^('ansi' | 'universal')$ /;
 
 # we can add more, but there is a qq:x call so whitelist is the way to go.
-constant @valid-terminals = < xterm xterm-256color vt100 screen screen-256color >;
+constant @valid-terminals = < xterm xterm-256color vt100 linux screen screen-256color >;
+
+class X::TputCapaMissing is Exception
+{
+	has Str $.term;
+	has Str $.capa;
+	method message() { "Tried to use an undefined capability '$.capa' of the terminal type '$.term'." }
+}
 
 my %tput-cache;
 BEGIN {
@@ -32,18 +40,25 @@ BEGIN {
 
     my @caps = << clear smcup rmcup sc rc civis cnorm "cup 13 13" "ech 1" >>;
 
+    sub query-cap(Str $term, Str $cap)
+    {
+	    my $proc = run 'tput', '-T', $term, $cap, :out;
+	    return $proc.out.slurp if $proc.exitcode == 0;
+	    return query-cap($term, "clear") if $cap ~~ /^ <[sr]>mcup $/;
+	    # TODO: Replace the -1 with a Failure.new(...) once the compiler can cope with it correctly.
+	    -1; # We use the "-1" as a poor man's Failure (we die whenever we try to use it)
+    }
+
     for @valid-terminals -> $term {
         for @caps -> $cap {
-            %tput-cache{$term}{$cap.words[0]} = qq:x{ tput -T $term $cap };
+            %tput-cache{$term}{$cap.words[0]} = query-cap($term, $cap.words[0]);
         }
     }
 }
 
 my $term = %*ENV<TERM> || 'xterm';
-my %cached := %tput-cache{$term};
-
-die "Please update @valid-terminals with your desired TERM ('$term', is it?) and submit a PR if it works"
-    unless %cached;
+die "Please update @valid-terminals with your desired TERM ('$term', is it?) and submit a PR if it works" unless %tput-cache{$term}:exists;
+my %cached = %tput-cache{$term};
 
 my Str sub ansi( Int() $x,  Int() $y ) {
     "\e[{$y+1};{$x+1}H";
@@ -101,13 +116,32 @@ sub tput( Str $command ) is export {
     die "Not a supported (or perhaps even valid) tput command"
         unless %tput-commands{$command};
 
+    die X::TputCapaMissing.new(term => $term, capa => $command) if %tput-commands{$command} ~~ -1;
     %tput-commands{$command};
 }
 
 sub print-command($command, Terminal::Print::CursorProfile $profile = 'ansi') is export {
+    die X::TputCapaMissing.new(term => $term, capa => %human-command-names{$command}) if %human-commands{$command} ~~ -1;
     if $profile eq 'debug' {
         return %human-commands{$command}.comb.join(' ');
     } else {
         print %human-commands{$command};
     }
+}
+
+CATCH
+{
+	when X::TputCapaMissing
+	{
+		# If we're just dying because of a missing capa, we need to clean up as much as we can
+		# (with some other capa's potentially missing) and ensure that the error message is not cleared.
+		my ($clear, $rmcup, $cnorm) = tput("clear"), tput("rmcup"), tput("cnorm");
+		print $clear if $clear !~~ -1; 
+		print $rmcup if $rmcup !~~ -1;
+		print $cnorm if $cnorm !~~ -1;
+
+		.rethrow; # we cleared the screen meanwhile, so we print the exception again
+	}
+}
+
 }


### PR DESCRIPTION
Done a few things, namely:

1) Changed the 'unit module' to a 'module { }' because the former triggers a compiler bug (if an exception is ever thrown and there is a CATCH in the module -- no matter what it does)
2) Added 'linux' to the terminal whitelist. (The terminals that you get after doing a Ctrl+Alt+Fx (0<x<7) are typically of this type.)
3) Whenever a 'smcup' or 'rmcup' capability is not found in the termcap database, we replace it with a 'clear' capability.
4) Whenever any other capability is not found in the database, we only store a '-1' in the appropriate hash. If the '-1' would ever have to be printed, we die. (This was supposed to use Failures, but these trigger only more compiler bugs.)
5) Eliminated a potential bug which would, when the module would be used on a non-whitelisted terminal type, make the program fail with something like 'Type check in binding failed, expected Associative, got Any' instead of the nice die message.

Sadly I don't know how to make good tests for this (it generally needs messing with the TERM variable and having the correct termcap database records). I would be happy to remedy if anybody has an idea how to make them well.