### PR TITLE
Add tmux as valid `$TERM` types

### DIFF
--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -26,7 +26,7 @@ subset Terminal::Print::CursorProfile is export where * ~~ / ^('ansi' | 'univers
 
 # we can add more, but there is a qq:x call so whitelist is the way to go.
 constant @valid-terminals = < xterm xterm-256color vt100 linux screen screen-256color
-                              screen.xterm-256color >;
+                              screen.xterm-256color tmux tmux-256color >;
 
 class X::TputCapaMissing is Exception
 {


### PR DESCRIPTION
tmux pretends it's screen by default, but also has its own terminfo which is a superset of that (more keyboard input escapes, mainly).