### PR TITLE
Add kitty to the list of acceptable terminals

### DIFF
--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -26,7 +26,7 @@ subset Terminal::Print::CursorProfile is export where * ~~ / ^('ansi' | 'univers
 
 # we can add more, but there is a qq:x call so whitelist is the way to go.
 constant @valid-terminals = < xterm xterm-256color vt100 linux screen screen-256color
-                              screen.xterm-256color tmux tmux-256color >;
+                              screen.xterm-256color tmux tmux-256color xterm-kitty >;
 
 class X::TputCapaMissing is Exception
 {


### PR DESCRIPTION
So far as I can tell, Kitty works fine with this library.