### PR TITLE
Add rxvt-unicode-256color as a valid terminal

### DIFF
--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -26,7 +26,8 @@ subset Terminal::Print::CursorProfile is export where * ~~ / ^('ansi' | 'univers
 
 # we can add more, but there is a qq:x call so whitelist is the way to go.
 constant @valid-terminals = < xterm xterm-256color vt100 linux screen screen-256color
-                              screen.xterm-256color tmux tmux-256color >;
+                              screen.xterm-256color tmux tmux-256color
+                              rxvt-unicode-256color >;
 
 class X::TputCapaMissing is Exception
 {


### PR DESCRIPTION
Added urxvt as a valid terminal type.  I ran all the examples in this terminal and everything seems to be ok.