### PR TITLE
A couple of improvements to the framework

### DIFF
--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -182,6 +182,8 @@ multi method change-cell($x, $y, %c) {
     @!grid[$y][$x] = Cell.new(|%c);
 }
 
+multi method change-cell($x, $y, *%c) { samewith($x, $y, %c) }
+
 #| Replace the contents of a single grid cell with a single uncolored/unstyled character
 multi method change-cell($x, $y, Str $char) {
     return unless 0 <= $x < $!w && 0 <= $y < $!h;
@@ -215,6 +217,8 @@ multi method print-cell($x, $y, %c) {
     self.change-cell($x, $y, Cell.new(|%c));
     self.print-cell($x, $y);
 }
+
+multi method print-cell($x, $y, *%c where *.elems) { samewith($x, $y, %c) }
 
 #| Degenerate case: print an individual cell
 multi method print-string($x, $y) {

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -44,10 +44,26 @@ method rows    { $!h }
 method height  { $!h }
 
 #| Instantiate a new (row-major) grid of size $w x $h
-method new($w, $h, :$move-cursor = move-cursor-template) {
-    my @grid = [ [ ' ' xx $w ] xx $h ];
+method new($w, $h, :@grid is copy, :$move-cursor = move-cursor-template) {
+    for ^$h -> $row {
+        my @grid-row = [ ' ' xx $w ];
+        if $row < @grid {
+            my $splice-w = $w > @grid[$row] ?? @grid[$row].elems !! $w;
+            @grid-row.splice(0, $splice-w, @grid[$row][0..^$splice-w]);
+        }
+        @grid[$row] = @grid-row;
+    }
 
     self.bless(:$w, :$h, :@grid, :$move-cursor);
+}
+
+#| Create a new grid based on self with possibly some parameters changed. Grid content is not preserved.
+method new-from-self(::?CLASS:D: *%args) {
+    self.WHAT.new( $!w, $!h, :$!move-cursor, |%args )
+}
+
+method clone(::?CLASS:D: *%args) {
+    self.WHAT.new( $!w, $!h, :$!move-cursor, :@!grid, |%args )
 }
 
 #| Clear the grid to blanks (ASCII spaces) with no color/style overrides

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -8,7 +8,7 @@ unit monitor Terminal::Print::Grid;
 #| Internal (immutable) class holding all position-independent information about a single grid cell
 my class Cell {
     use Terminal::ANSIColor; # lexical imports FTW
-    has $.char is required;
+    has Str:D $.char is required where *.chars == 1;
     has $.color;
     has $!string;
 


### PR DESCRIPTION
I'm playing with writing own simplistic `Term::UI` framework and decided to base it on your work. But a couple of changes was needed to make this possible. So, here is the result.

Besides, I have implemented basic support for terminal size change by allowing on-the-fly resetup of `Terminal::Print` instance. It's up to the user application though to react on `SIGWINCH` and initiate the reconfiguration.