### PR TITLE
Support passing a cell hash to change-cell

### DIFF
--- a/lib/Terminal/Print.pm6
+++ b/lib/Terminal/Print.pm6
@@ -235,7 +235,11 @@ class Terminal::Print {
         $!current-grid.print-string($x, $y, $string, $color);
     }
 
-    method change-cell( $x, $y, Str $c ) {
+    multi method change-cell( $x, $y, %c ) {
+        $!current-grid.change-cell($x, $y, %c);
+    }
+
+    multi method change-cell( $x, $y, Str $c ) {
         $!current-grid.change-cell($x, $y, $c);
     }
 


### PR DESCRIPTION
Although Terminal::Print::Grid supports calling

```
$grid.change-cell( $x, $y, %cell )
```

this was not supported from the parent Terminal::Print object, which only accepted

```
T.change-cell( $x, $y, $string )
```

Assuming this was an oversight, this patch adds support for this.
