### PR TITLE
Use constants for method constraints in BoxDrawing

### DIFF
--- a/lib/Terminal/Print/BoxDrawing.pm6
+++ b/lib/Terminal/Print/BoxDrawing.pm6
@@ -3,56 +3,63 @@
 #
 
 #| Unicode horizontal lines in different patterns, with ASCII fallback
-my %hline = ascii  => '-', double => '═',
-            light1 => '─', light2 => '╌', light3 => '┄', light4 => '┈',
-            heavy1 => '━', heavy2 => '╍', heavy3 => '┅', heavy4 => '┉';
+my constant HLINE = %(
+    ascii  => '-', double => '═',
+    light1 => '─', light2 => '╌', light3 => '┄', light4 => '┈',
+    heavy1 => '━', heavy2 => '╍', heavy3 => '┅', heavy4 => '┉',
+);
 
 #| Unicode vertical lines in different patterns, with ASCII fallback
-my %vline = ascii  => '|', double => '║',
-            light1 => '│', light2 => '╎', light3 => '┆', light4 => '┊',
-            heavy1 => '┃', heavy2 => '╏', heavy3 => '┇', heavy4 => '┋';
+my constant VLINE = %(
+    ascii  => '|', double => '║',
+    light1 => '│', light2 => '╎', light3 => '┆', light4 => '┊',
+    heavy1 => '┃', heavy2 => '╏', heavy3 => '┇', heavy4 => '┋',
+);
 
 #| Overall weight for each line pattern, with ASCII fallback
-my %weight = ascii  => 'ascii', double => 'double',
-             light1 => 'light', light2 => 'light',
-             light3 => 'light', light4 => 'light',
-             heavy1 => 'heavy', heavy2 => 'heavy',
-             heavy3 => 'heavy', heavy4 => 'heavy';
+my constant WEIGHT = %(
+    ascii  => 'ascii', double => 'double',
+    light1 => 'light', light2 => 'light',
+    light3 => 'light', light4 => 'light',
+    heavy1 => 'heavy', heavy2 => 'heavy',
+    heavy3 => 'heavy', heavy4 => 'heavy',
+);
 
 #| Box corner characters for each line weight (+ round), with ASCII fallback
-my %corners = ascii  => < + + + + >,
-              double => < ╔ ╗ ╚ ╝ >,
-              light  => < ┌ ┐ └ ┘ >,
-              heavy  => < ┏ ┓ ┗ ┛ >,
-              round  => < ╭ ╮ ╰ ╯ >;
-
+my constant CORNERS = %(
+    ascii  => < + + + + >,
+    double => < ╔ ╗ ╚ ╝ >,
+    light  => < ┌ ┐ └ ┘ >,
+    heavy  => < ┏ ┓ ┗ ┛ >,
+    round  => < ╭ ╮ ╰ ╯ >,
+);
 
 #| Enhance a T::P::Widget to draw boxes and horizontal / vertical lines
 role Terminal::Print::BoxDrawing {
-    has $.default-box-style = 'double';  #= Line type chosen from %hline and %vline
+    has $.default-box-style = 'double';  #= Line type chosen from HLINE and VLINE
 
     #| Draw a horizontal line in a chosen color
-    multi method draw-hline($x1, $x2, $y, :$color!, :$style where %hline = $.default-box-style) {
-        $.grid.set-span($x1, $y, %hline{$style} x ($x2 - $x1 + 1), $color);
+    multi method draw-hline($x1, $x2, $y, :$color!, :$style where HLINE = $.default-box-style) {
+        $.grid.set-span($x1, $y, HLINE{$style} x ($x2 - $x1 + 1), $color);
     }
 
     #| Draw a horizontal line without altering color
-    multi method draw-hline($x1, $x2, $y, :$style where %hline = $.default-box-style) {
-        $.grid.set-span-text($x1, $y, %hline{$style} x ($x2 - $x1 + 1));
+    multi method draw-hline($x1, $x2, $y, :$style where HLINE = $.default-box-style) {
+        $.grid.set-span-text($x1, $y, HLINE{$style} x ($x2 - $x1 + 1));
     }
 
     #| Draw a vertical line in a chosen color
-    multi method draw-vline($x, $y1, $y2, :$color!, :$style where %vline = $.default-box-style) {
-        $.grid.set-span($x, $_, %vline{$style}, $color) for $y1..$y2;
+    multi method draw-vline($x, $y1, $y2, :$color!, :$style where VLINE = $.default-box-style) {
+        $.grid.set-span($x, $_, VLINE{$style}, $color) for $y1..$y2;
     }
 
     #| Draw a vertical line without altering color
-    multi method draw-vline($x, $y1, $y2, :$style where %vline = $.default-box-style) {
-        $.grid.set-span-text($x, $_, %vline{$style}) for $y1..$y2;
+    multi method draw-vline($x, $y1, $y2, :$style where VLINE = $.default-box-style) {
+        $.grid.set-span-text($x, $_, VLINE{$style}) for $y1..$y2;
     }
 
     #| Draw a box in a chosen color
-    multi method draw-box($x1, $y1, $x2, $y2, :$color!, :$style where %hline = $.default-box-style) {
+    multi method draw-box($x1, $y1, $x2, $y2, :$color!, :$style where HLINE = $.default-box-style) {
         # Draw sides in order: left, right, top, bottom
         self.draw-vline($x1, $y1 + 1, $y2 - 1, :$color, :$style);
         self.draw-vline($x2, $y1 + 1, $y2 - 1, :$color, :$style);
@@ -60,7 +67,7 @@ role Terminal::Print::BoxDrawing {
         self.draw-hline($x1 + 1, $x2 - 1, $y2, :$color, :$style);
 
         # Draw corners
-        my @corners = |%corners{%weight{$style}};
+        my @corners = |CORNERS{WEIGHT{$style}};
         $.grid.set-span($x1, $y1, @corners[0], $color);
         $.grid.set-span($x2, $y1, @corners[1], $color);
         $.grid.set-span($x1, $y2, @corners[2], $color);
@@ -68,7 +75,7 @@ role Terminal::Print::BoxDrawing {
     }
 
     #| Draw a box without altering color
-    multi method draw-box($x1, $y1, $x2, $y2, :$style where %hline = $.default-box-style) {
+    multi method draw-box($x1, $y1, $x2, $y2, :$style where HLINE = $.default-box-style) {
         # Draw sides in order: left, right, top, bottom
         self.draw-vline($x1, $y1 + 1, $y2 - 1, :$style);
         self.draw-vline($x2, $y1 + 1, $y2 - 1, :$style);
@@ -76,7 +83,7 @@ role Terminal::Print::BoxDrawing {
         self.draw-hline($x1 + 1, $x2 - 1, $y2, :$style);
 
         # Draw corners
-        my @corners = |%corners{%weight{$style}};
+        my @corners = |CORNERS{WEIGHT{$style}};
         $.grid.set-span-text($x1, $y1, @corners[0]);
         $.grid.set-span-text($x2, $y1, @corners[1]);
         $.grid.set-span-text($x1, $y2, @corners[2]);

--- a/t/20-boxdrawing.t
+++ b/t/20-boxdrawing.t
@@ -1,0 +1,63 @@
+use Test;
+
+use Terminal::Print::Widget;
+use Terminal::Print::BoxDrawing;
+use Terminal::ANSIColor;
+
+class A is Terminal::Print::Widget does Terminal::Print::BoxDrawing {
+    method TWEAK { self.grid.disable }
+
+    method border-check($expected, :$color, :$style) {
+        self.draw-box(
+            0, 0, self.w - 1, self.h - 1,
+            |( :$color if $color ),
+            |( :$style if $style )
+        );
+
+        my $cells = self.grid.grid.join;
+        is $cells.&colorstrip, $expected,
+            ( $style || 'default' ) ~ ( $color ?? ' with color' !! '' );
+
+        return unless $color;
+
+        is $cells.&uncolor,
+            ( "$color reset" xx self.w * self.h - 1 ).join(' '),
+            $color;
+    }
+}
+
+my $widget = A.new(x => 0, y => 0, h => 3, w => 3);
+
+for %(
+     default => '╔ ═ ╗║   ║╚ ═ ╝',
+     ascii   => '+ - +|   |+ - +',
+     light1  => '┌ ─ ┐│   │└ ─ ┘',
+     light2  => '┌ ╌ ┐╎   ╎└ ╌ ┘',
+     light3  => '┌ ┄ ┐┆   ┆└ ┄ ┘',
+     light4  => '┌ ┈ ┐┊   ┊└ ┈ ┘',
+     heavy1  => '┏ ━ ┓┃   ┃┗ ━ ┛',
+     heavy2  => '┏ ╍ ┓╏   ╏┗ ╍ ┛',
+     heavy3  => '┏ ┅ ┓┇   ┇┗ ┅ ┛',
+     heavy4  => '┏ ┉ ┓┋   ┋┗ ┉ ┛',
+     double  => '╔ ═ ╗║   ║╚ ═ ╝',
+).kv -> $style, $expected {
+    $widget.border-check(
+        $expected,
+        |( :$style unless $style eq 'default' )
+    );
+
+    $widget.border-check(
+        $expected,
+        |( :$style unless $style eq 'default' ),
+        color => 'red',
+    );
+}
+
+dies-ok { $widget.draw-box( 0, 0, 2, 2, style => 'missing' ) },
+    'Validates style names without color';
+
+dies-ok { $widget.draw-box( 0, 0, 2, 2, color => 'red', style => 'missing' ) },
+    'Validates style names with color';
+
+
+done-testing;


### PR DESCRIPTION
Rakudo does not seem to allow constraints that use hashes in role methods (see https://github.com/rakudo/rakudo/issues/3172), but the issue disappears if the hashes are declared as constants rather.

At least until the issue is resolved upstream, this allows classes to consume the BoxDrawing role without needing to disable precompilation.

Fixes #74.