### PR TITLE
Make the dependency chain free of native code

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
   "depends": [
     "OO::Monitors",
     "Terminal::ANSIColor",
-    "Term::termios:ver<0.2>",
+    "Terminal::MakeRaw",
     "File::Which"
   ],
   "description": "Asynchronous printing to your terminal -- as a simple grid",


### PR DESCRIPTION
This means that installing this module won't require a C compiler toolchain anymore.
Do so by replacing Term::termios with Terminal::MakeRaw.

I just now uploaded Terminal::MakeRaw to the ecosystem. So it might take a few minutes for it to become actually available.