### PR TITLE
Reapply switch to Terminal-API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          # - windows-latest
+          - windows-latest
         raku-version:
           - 'latest'
           # - '2022.02'

--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
   "depends": [
     "OO::Monitors",
     "Terminal::ANSIColor",
-    "Terminal::MakeRaw",
+    "Terminal::API:auth<zef:patrickb>:ver<1.0.1>",
     "File::Which"
   ],
   "description": "Asynchronous printing to your terminal -- as a simple grid",

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ perl6 -Ilib examples/matrix-ish.p6
 perl6 -Ilib examples/async.p6
 ````
 
-By default the `Terminal::Print` object will use ANSI escape sequences for its cursor drawing, but you can tell it to use `universal` if you would prefer to use the cursor movement commands as provided by `tput`. (You should only really need this if you are having trouble with the default).
-
-```
-my $t = Terminal::Print.new(cursor-profile => 'universal')
-```
-
 ## History
 
 At first I thought I might try writing a NativeCall wrapper around ncurses. Then I realized that there is absolutely no reason to fight a C library which has mostly bolted on Unicode when I can do it in Pure Perl 6, with native Unicode goodness.

--- a/examples/alphabetics.p6
+++ b/examples/alphabetics.p6
@@ -3,7 +3,7 @@
 use v6;
 use Terminal::Print;
 
-my $p = Terminal::Print.new(cursor-profile => 'universal');
+my $p = Terminal::Print.new();
 
 $p.initialize-screen;
 

--- a/lib/Terminal/Print.pm6
+++ b/lib/Terminal/Print.pm6
@@ -76,19 +76,14 @@ class Terminal::Print:auth<zef:terminal-printers>:api<1>:ver<0.976> {
     subset Valid::Y of Int is export where * < rows();
     subset Valid::Char of Str is export where *.chars == 1;
 
-    has Terminal::Print::CursorProfile $.cursor-profile;
-    has $.move-cursor;
-
-    method new( :$cursor-profile = 'ansi' ) {
+    method new() {
         my $columns      = columns();
         my $rows         = rows();
-        my $move-cursor  = move-cursor-template($cursor-profile);
-        my $current-grid = Terminal::Print::Grid.new( $columns, $rows, :$move-cursor );
-        self.bless( :$columns, :$rows, :$current-grid,
-                    :$cursor-profile,  :$move-cursor );
+        my $current-grid = Terminal::Print::Grid.new( $columns, $rows );
+        self.bless( :$columns, :$rows, :$current-grid );
     }
 
-    submethod BUILD( :$!current-grid, :$!columns, :$!rows, :$!cursor-profile, :$!move-cursor ) {
+    submethod BUILD( :$!current-grid, :$!columns, :$!rows ) {
         push @!grids, $!current-grid;
 
         # set up a tap on SIGINT so that we can cleanly shutdown, restoring the previous screen and cursor
@@ -104,7 +99,7 @@ class Terminal::Print:auth<zef:terminal-printers>:api<1>:ver<0.976> {
         %!root-widget-map{$grid} ||= Terminal::Print::Widget.new-from-grid($grid);
     }
 
-    method add-grid( $name?, :$new-grid = Terminal::Print::Grid.new( $!columns, $!rows, :$!move-cursor ) ) {
+    method add-grid( $name?, :$new-grid = Terminal::Print::Grid.new( $!columns, $!rows ) ) {
         push @!grids, $new-grid;
         if $name {
             %!grid-name-map{$name} = +@!grids-1;
@@ -147,7 +142,7 @@ class Terminal::Print:auth<zef:terminal-printers>:api<1>:ver<0.976> {
     }
 
     method print-command( $command ) {
-        print-command($command, $!cursor-profile);
+        print-command($command);
     }
 
     # AT-POS hands back a Terminal::Print::Column

--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -13,6 +13,7 @@ a bit nicer.
 =end pod
 
 use File::Which;
+use Terminal::API;
 
 our %human-command-names;
 our %human-commands;
@@ -101,8 +102,8 @@ for %human-command-names.kv -> $human,$command {
     %human-commands{$human} = %tput-commands{$command};
 }
 
-sub columns is export { q:x{ tput cols  } .chomp.Int }
-sub rows    is export { q:x{ tput lines } .chomp.Int }
+sub columns is export { Terminal::API::get-window-size().cols }
+sub rows    is export { Terminal::API::get-window-size().rows }
 
 sub move-cursor-template( Terminal::Print::CursorProfile $profile = 'ansi' ) returns Code is export {
     $profile eq 'ansi' ?? &ansi !! &universal

--- a/lib/Terminal/Print/Commands.pm6
+++ b/lib/Terminal/Print/Commands.pm6
@@ -15,134 +15,27 @@ a bit nicer.
 use File::Which;
 use Terminal::API;
 
-our %human-command-names;
-our %human-commands;
-our %tput-commands;
-
 our @fg_colors = [ <black red green yellow blue magenta cyan white default> ];
 our @bg_colors = [ <on_black on_red on_green on_yellow on_blue on_magenta on_cyan on_white on_default> ];
 our @styles    = [ <reset bold underline inverse> ];
 
-subset Terminal::Print::CursorProfile is export where * ~~ / ^('ansi' | 'universal')$ /;
-
-# we can add more, but there is a qq:x call so whitelist is the way to go.
-
-constant @valid-terminals = < xterm xterm-256color vt100 linux screen screen-256color rxvt
-                              screen.xterm-256color tmux tmux-256color xterm-kitty rxvt-unicode-256color st-256color alacritty>;
-
-class X::TputCapaMissing is Exception
-{
-	has Str $.term;
-	has Str $.capa;
-	method message() { "Tried to use an undefined capability '$.capa' of the terminal type '$.term'." }
-}
-
-my %tput-cache;
-BEGIN {
-    die 'Cannot use Terminal::Print without `tput` (usually provided by `ncurses`)'
-        unless which('tput');
-
-    my @caps = << clear smcup rmcup sc rc civis cnorm "cup 13 13" "ech 1" >>;
-
-    sub query-cap(Str $term, Str $cap)
-    {
-	    my $proc = run 'tput', '-T', $term, $cap, :out;
-	    return $proc.out.slurp if $proc.exitcode == 0;
-	    return query-cap($term, "clear") if $cap ~~ /^ <[sr]>mcup $/;
-	    # TODO: Replace the -1 with a Failure.new(...) once the compiler can cope with it correctly.
-	    -1; # We use the "-1" as a poor man's Failure (we die whenever we try to use it)
-    }
-
-    for @valid-terminals -> $term {
-        for @caps -> $cap {
-            %tput-cache{$term}{$cap.words[0]} = query-cap($term, $cap.words[0]);
-        }
-    }
-}
-
-my $term = %*ENV<TERM> || 'xterm';
-die "Please update @valid-terminals with your desired TERM ('$term', is it?) and submit a PR if it works" unless %tput-cache{$term}:exists;
-my %cached = %tput-cache{$term};
-
-my Str sub ansi( Int() $x,  Int() $y ) {
-    "\e[{$y+1};{$x+1}H";
-}
-
-my $raw = %cached<cup>;
-$raw ~~ /^ (.*?) (\d+) (\D+) (\d+) (\D+) $/
-    or warn "universal mode must have access to tput";
-
-my ($pre, $mid, $post) = $0, $2, $4;
-
-my Str sub universal( Int() $x, Int() $y ) {
-    $pre ~ ($y + 1) ~ $mid ~ ($x + 1) ~ $post;
-}
-
-%human-command-names = %(
-    'clear'              => 'clear',
-    'save-screen'        => 'smcup',
-    'restore-screen'     => 'rmcup',
-    'pos-cursor-save'    => 'sc',
-    'pos-cursor-restore' => 'rc',
-    'hide-cursor'        => 'civis',
-    'show-cursor'        => 'cnorm',
-    'move-cursor'        => 'cup',
-    'erase-char'         => 'ech',
-);
-
-for %human-command-names.kv -> $human,$command {
-    given $human {
-        when 'move-cursor'  {
-            %tput-commands{$command} = %( :&ansi, :&universal );
-        }
-        default             {
-            %tput-commands{$command} = %cached{$command};
-        }
-    }
-    %human-commands{$human} = %tput-commands{$command};
-}
+my %commands =
+    clear => "\e[H\e[2J\e[3J",
+    save-screen => "\e[?1049h\e[22;0;0t",
+    restore-screen => "\e[?1049l\e[23;0;0t",
+    hide-cursor => "\e[?25l",
+    show-cursor => "\e[?12l\e[?25h",
+;
 
 sub columns is export { Terminal::API::get-window-size().cols }
 sub rows    is export { Terminal::API::get-window-size().rows }
 
-sub move-cursor-template( Terminal::Print::CursorProfile $profile = 'ansi' ) returns Code is export {
-    $profile eq 'ansi' ?? &ansi !! &universal
+sub move-cursor(Int $x, Int $y) is export {
+    "\e[{$y+1};{$x+1}H"
 }
 
-sub move-cursor( Int $x, Int $y, Terminal::Print::CursorProfile $profile = 'ansi' ) is export {
-    ($profile eq 'ansi' ?? &ansi !! &universal)( $x, $y )
-}
-
-sub tput( Str $command ) is export {
-    die "Not a supported (or perhaps even valid) tput command"
-        unless %tput-commands{$command};
-
-    die X::TputCapaMissing.new(term => $term, capa => $command) if %tput-commands{$command} ~~ -1;
-    %tput-commands{$command};
-}
-
-sub print-command($command, Terminal::Print::CursorProfile $profile = 'ansi') is export {
-    die X::TputCapaMissing.new(term => $term, capa => %human-command-names{$command}) if %human-commands{$command} ~~ -1;
-    if $profile eq 'debug' {
-        return %human-commands{$command}.comb.join(' ');
-    } else {
-        print %human-commands{$command};
-    }
-}
-
-CATCH
-{
-	when X::TputCapaMissing
-	{
-		# If we're just dying because of a missing capa, we need to clean up as much as we can
-		# (with some other capa's potentially missing) and ensure that the error message is not cleared.
-		my ($clear, $rmcup, $cnorm) = tput("clear"), tput("rmcup"), tput("cnorm");
-		print $clear if $clear !~~ -1; 
-		print $rmcup if $rmcup !~~ -1;
-		print $cnorm if $cnorm !~~ -1;
-
-		.rethrow; # we cleared the screen meanwhile, so we print the exception again
-	}
+sub print-command($command) is export {
+    print %commands{$command};
 }
 
 }

--- a/lib/Terminal/Print/Grid.pm6
+++ b/lib/Terminal/Print/Grid.pm6
@@ -84,7 +84,6 @@ has $.h;
 has @!indices;
 has @.grid;
 has $.grid-string = '';
-has $.move-cursor;
 has $!print-enabled = True;
 
 # Compatibility accessors
@@ -94,10 +93,10 @@ method rows    { $!h }
 method height  { $!h }
 
 #| Instantiate a new (row-major) grid of size $w x $h
-method new($w, $h, :$move-cursor = move-cursor-template) {
+method new($w, $h) {
     my @grid = [ [ ' ' xx $w ] xx $h ];
 
-    self.bless(:$w, :$h, :@grid, :$move-cursor);
+    self.bless(:$w, :$h, :@grid);
 }
 
 #| Clear the grid to blanks (ASCII spaces) with no color/style overrides
@@ -112,13 +111,13 @@ method indices() {
 
 #| Return the escape string necessary to move to, color, and output a single cell
 method cell-string($x, $y) {
-    "{$!move-cursor($x, $y)}{~@!grid[$y][$x]}"
+    "{move-cursor($x, $y)}{~@!grid[$y][$x]}"
 }
 
 #| Return the escape string necessary to move to (x1, y) and output every cell (with color) on that row from x1..x2
 method span-string($x1, $x2, $y) {
     my $row = @!grid[$y];
-    $!move-cursor($x1, $y) ~ $row[$x1..$x2].join.subst("\e[0m\e[", "\e[0;", :g);
+    move-cursor($x1, $y) ~ $row[$x1..$x2].join.subst("\e[0m\e[", "\e[0;", :g);
 }
 
 #| Set both the text and sgr color of a span

--- a/lib/Terminal/Print/RawInput.pm6
+++ b/lib/Terminal/Print/RawInput.pm6
@@ -2,7 +2,7 @@ use v6.d.PREVIEW;
 unit module Terminal::Print::RawInput;
 
 # For TTY raw mode
-use Terminal::MakeRaw;
+use Terminal::API;
 
 #| Convert an input stream to a Supply of individual characters
 #  Reads bytes in order to work around lower-layer grapheme combiner handling
@@ -11,11 +11,11 @@ sub raw-input-supply(IO::Handle $input = $*IN,
                      Bool :$drop-old-unread) is export {
     # If a TTY, convert to raw mode, saving current mode first
     my $fd = $input.native-descriptor;
-    my $saved-termios;
+    my $saved-term-config;
     if $input.t {
-        $saved-termios = Terminal::MakeRaw::getattr($fd);
-        my $mode       = $drop-old-unread ?? :FLUSH !! :DRAIN;
-        Terminal::MakeRaw::makeraw($fd, |$mode);
+        $saved-term-config = Terminal::API::get-config($fd);
+        my $when           = $drop-old-unread ?? Terminal::API::FLUSH !! Terminal::API::DRAIN;
+        Terminal::API::make-raw($fd, :$when);
     }
 
     # Cancelable character supply loop; emits a character as soon as any
@@ -39,7 +39,7 @@ sub raw-input-supply(IO::Handle $input = $*IN,
     }
     $s.Supply.on-close: {
         # Restore saved TTY mode if any
-        Terminal::MakeRaw::setattr($fd, $saved-termios, :DRAIN) if $saved-termios;
+        Terminal::API::restore-config($saved-term-config, $fd, :when(Terminal::API::DRAIN)) if $saved-term-config;
         $done = True;
     }
 }

--- a/t/00-basics.t
+++ b/t/00-basics.t
@@ -2,7 +2,7 @@ use Test;
 use lib 'lib';
 
 chdir('t');
-plan 4;
+plan 2;
 
 sub slurp-corpus($topic) {
     "corpus/$topic".IO.slurp;
@@ -12,12 +12,6 @@ use Terminal::Print; pass "Import Terminal::Print";
 
 my $b = Terminal::Print.new;
 lives-ok { my $t = Terminal::Print.new; }, "Can create a Terminal::Print object";
-
-lives-ok { my $t = Terminal::Print.new( :cursor-profile('universal') ) },
-    "Can create Terminal::Print object with print-profile 'universal'";
-
-dies-ok { my $t = Terminal::Print.new( :cursor-profile('nonexistent') ) },
-    "Cannot create Terminal::Print object with print-profile 'nonexistent'";
 
 #ok $b.print-command('save-screen') eq slurp-corpus('save-screen'), ".save-screen matches corpus";
 #ok $b.print-command('restore-screen') eq slurp-corpus('restore-screen'), ".restore-screen matches corpus";


### PR DESCRIPTION
As requested, getting rid of `tput` is now in a separate commit.